### PR TITLE
Upgrade Electron (to 10)

### DIFF
--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.jamovi.jamovi",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "20.08",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "19.08",
+    "base-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "jamovi",
     "separate-locales": false,
@@ -284,30 +284,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/electron/electron/releases/download/v6.1.9/electron-v6.1.9-linux-x64.zip",
-                    "sha512": "0e3d4df5bf358d6d8630ad461057cf497843015c6b87b8939df4f03b2d1229bc6a9c2b05efb8afdc9917a0dd2f7defd24c38bfeffb2cd081b5376825a9d11f41",
-                    "strip-components": 0
-                }
-            ]
-        },
-        {
-            "name": "electron-i386",
-            "only-arches": [ "i386" ],
-            "buildsystem": "simple",
-            "build-commands": [
-                "mkdir -p /app/bin/resources",
-                "cp *.so  /app/bin",
-                "cp *.bin /app/bin",
-                "cp *.dat /app/bin",
-                "cp *.pak /app/bin",
-                "cp electron /app/bin/",
-                "cp -r resources/ /app/bin/"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/electron/electron/releases/download/v6.1.9/electron-v6.1.9-linux-ia32.zip",
-                    "sha512": "f20d120f4968c10b350eea88f684f413d58152c4651b3a7f24d6a65afe3ff74d016f269d737ee9c9c3c91a4c73ca6aad468c7ecba72d12fcf4301048050eb0f3",
+                    "url": "https://github.com/electron/electron/releases/download/v11.2.3/electron-v11.2.3-linux-x64.zip",
+                    "sha512": "2c4f6ff41d262a1abf76e3b16ed3736f8d2aa49a5fa3c0f65a0b72bebb074baf2cc55a6960a69f9e38a6f0b72d74f37cc600c9ba483805160acdaa4d2d261edc",
                     "strip-components": 0
                 }
             ]

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.jamovi.jamovi",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "19.08",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "20.08",
+    "base-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "jamovi",
     "separate-locales": false,
@@ -162,9 +162,9 @@
             "name": "nodejs",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://nodejs.org/dist/v10.16.0/node-v10.16.0.tar.xz",
-                    "sha512": "df197c7b929fe1e0acf0334dbeb45be4c0cfa3266f9ddb513eafffcd6405bc02cba2fcbd34a7a5bef2e45a1d61ef3734ca0afe7295904ed563744fe06751cc62"
+                    "type": "archive",                 
+                    "url": "https://github.com/nodejs/node/archive/v12.20.2.tar.gz",
+                    "sha512": "e17793f7defb9b770f49f5be0810fe9f5c759a059eeba23bcbef15a723faba267b3e5d227b1d76bbae352154657178d77cdcb4714d575ccfd29a692d655d5579"
                 }
             ],
             "cleanup": [
@@ -284,30 +284,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/electron/electron/releases/download/v11.2.3/electron-v11.2.3-linux-x64.zip",
-                    "sha512": "2c4f6ff41d262a1abf76e3b16ed3736f8d2aa49a5fa3c0f65a0b72bebb074baf2cc55a6960a69f9e38a6f0b72d74f37cc600c9ba483805160acdaa4d2d261edc",
-                    "strip-components": 0
-                }
-            ]
-        },
-        {
-            "name": "electron-arm",
-            "only-arches": [ "arm" ],
-            "buildsystem": "simple",
-            "build-commands": [
-                "mkdir -p ${FLATPAK_DEST}/bin/resources",
-                "cp *.so  ${FLATPAK_DEST}/bin",
-                "cp *.bin ${FLATPAK_DEST}/bin",
-                "cp *.dat ${FLATPAK_DEST}/bin",
-                "cp *.pak ${FLATPAK_DEST}/bin",
-                "cp electron ${FLATPAK_DEST}/bin/",
-                "cp -r resources/ ${FLATPAK_DEST}/bin/"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/electron/electron/releases/download/v6.1.9/electron-v6.1.9-linux-armv7l.zip",
-                    "sha512": "0e0895568d2b3304cc92d372a9e539dca3990c13283c5031a36c3ba0e09a7e06bff353e0373edbcea8981844df121160e0fcdd07ca3c4c1629ba458f7fe0cb2a",
+                    "url": "https://github.com/electron/electron/releases/download/v10.3.2/electron-v10.3.2-linux-x64.zip",
+                    "sha512": "de2e9f32ac2af376b08c9791b8720923f5083ccfe14de52a5a85e168a3592792defade25fb8ca5eda061cd5b8a88c47678df56d84dd5bf44d99c23959e49c8f3",
                     "strip-components": 0
                 }
             ]
@@ -328,8 +306,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/electron/electron/releases/download/v6.1.9/electron-v6.1.9-linux-arm64.zip",
-                    "sha512": "cfc53f479b5c2fac3f1f618283d7311f669354f0fa02b09281399cf3f212d0aa3e0a5873f9cc0fb2f9c5adcadc3ea41b7c6009cbc79f9737fac139cc667032e4",
+                    "url": "https://github.com/electron/electron/releases/download/v10.3.2/electron-v10.3.2-linux-arm64.zip",
+                    "sha512": "de4fc211b509a92e04275207a9b92821a4170743f15155f427e6c3af1c6dd3b0a319bd5957eb9457d28201fe0390d1ec0221a5e4492fca80da405f3d511fd098",
                     "strip-components": 0
                 }
             ]

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -291,6 +291,28 @@
             ]
         },
         {
+            "name": "electron-arm",
+            "only-arches": [ "arm" ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/bin/resources",
+                "cp *.so  ${FLATPAK_DEST}/bin",
+                "cp *.bin ${FLATPAK_DEST}/bin",
+                "cp *.dat ${FLATPAK_DEST}/bin",
+                "cp *.pak ${FLATPAK_DEST}/bin",
+                "cp electron ${FLATPAK_DEST}/bin/",
+                "cp -r resources/ ${FLATPAK_DEST}/bin/"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/electron/electron/releases/download/v10.3.2/electron-v10.3.2-linux-armv7l.zip",
+                    "sha512": "07c834e47cb1ec4c7a42233405179fc42a88a285f201d775da13e46a01dcc8341f2c1282332123fcfa297e2304e0d7b9a3d853cb0f844766b0f6ba7dfd933e40",
+                    "strip-components": 0
+                }
+            ]
+        },
+        {
             "name": "electron-arm64",
             "only-arches": [ "aarch64" ],
             "buildsystem": "simple",


### PR DESCRIPTION
- upgraded Electron (to v11.2.3)
- upgrade runtime (org.freedesktop.Platform) and base-app (org.electronjs.Electron2.BaseApp) to 20.08
- removed old code for 32-bit version (freedesktop support ended, therefore no chance to build)